### PR TITLE
add custom icon button component

### DIFF
--- a/CustomIconButton/index.js
+++ b/CustomIconButton/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import IconButton from '@material-ui/core/IconButton';
+import { withStyles } from '@material-ui/core';
+
+const styles = {
+    root: props => ({
+        color: props.iconColor ? props.iconColor : '#1976d2',
+        ...props.iconStyles
+    })
+}
+
+class Iconbutton extends React.Component {
+
+    render = () => <IconButton aria-label='icon-btn' color='default' disabled={this.props.disabled} {...this.props}>
+        {this.props.icon}
+    </IconButton>;
+}
+
+export default withStyles(styles)(Iconbutton);


### PR DESCRIPTION
A React IconButton component which can be used whenever a person wants to use an icon (Material Icon) as a button. Can be customized based on props passed to it.