### PR TITLE
Fix background color typo in scrollbar track in CSS

### DIFF
--- a/6) TinDog/css/styles.css
+++ b/6) TinDog/css/styles.css
@@ -16,9 +16,9 @@ html {
   width: 14px;
 }
 ::-webkit-scrollbar-track {
-  /* border: 2px solid #2d3748; */
-  background: rgb(255, 233, 233)209, 180, 180)209, 180, 180);
+  background: rgb(255, 233, 233); /* Correct syntax */
 }
+
 ::-webkit-scrollbar-thumb {
   background: linear-gradient(45deg, #ff4c68, #ef8172);
   border-radius: 10px;


### PR DESCRIPTION
This pull request resolves a typo in the CSS file related to the scrollbar track background color definition. 

### Changes:
- The incorrect line in the `::-webkit-scrollbar-track` selector:
  ```css
  background: rgb(255, 233, 233)209, 180, 180)209, 180, 180);
